### PR TITLE
Fix EC2 enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Version 0.2.1
+
+- Fix EC2 instance enumeration to use paging
+
 ## Version 0.2.0
 
 - Add more parameter and status checks

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ You can build and install this gem on your local system as well via a Rake task:
 | `execution_timeout`  | Maximum time until timeout                        | 60               |
 | `recheck_invocation` | Interval of rechecking AWS command invocation     | 1.0              |
 | `recheck_execution`  | Interval of rechecking completion of command      | 1.0              |
+| `instance_pagesize`  | Paging size for EC2 instance retrieval            | 100              |
 
 ## Limitations
 

--- a/lib/train-awsssm/transport.rb
+++ b/lib/train-awsssm/transport.rb
@@ -11,6 +11,7 @@ module TrainPlugins
       option :execution_timeout,  default: 60.0
       option :recheck_invocation, default: 1.0
       option :recheck_execution,  default: 1.0
+      option :instance_pagesize,  default: 100
 
       def connection(_instance_opts = nil)
         @connection ||= TrainPlugins::AWSSSM::Connection.new(@options)

--- a/lib/train-awsssm/version.rb
+++ b/lib/train-awsssm/version.rb
@@ -1,5 +1,5 @@
 module TrainPlugins
   module AWSSSM
-    VERSION = "0.2.0".freeze
+    VERSION = "0.2.1".freeze
   end
 end


### PR DESCRIPTION
### Description

Fixes EC2 instance enumeration (for IP/DNS to instance ID conversion) to use paging.

### Issues Resolved

Previously, not all instances might have been returned - resulting in an instance ID lookup failure.

### Check List

- [X] New functionality has been documented in the README if applicable

