### PR TITLE
Add support for file_via_connection

### DIFF
--- a/lib/train-awsssm/connection.rb
+++ b/lib/train-awsssm/connection.rb
@@ -30,6 +30,10 @@ module TrainPlugins
         CommandResult.new(stdout, stderr, exit_status)
       end
 
+      def file_via_connection(path)
+        windows_instance? ? Train::File::Remote::Windows.new(self, path) : Train::File::Remote::Unix.new(self, path)
+      end
+
       def execute_on_channel(cmd, &data_handler)
         logger.debug format("[AWS-SSM] Command: '%s'", cmd)
 

--- a/lib/train-awsssm/connection.rb
+++ b/lib/train-awsssm/connection.rb
@@ -30,8 +30,18 @@ module TrainPlugins
         CommandResult.new(stdout, stderr, exit_status)
       end
 
-      def file_via_connection(path)
-        windows_instance? ? Train::File::Remote::Windows.new(self, path) : Train::File::Remote::Unix.new(self, path)
+      def file_via_connection(path, *args)
+        if os.aix?
+          Train::File::Remote::Aix.new(self, path, *args)
+        elsif os.solaris?
+          Train::File::Remote::Unix.new(self, path, *args)
+        elsif os[:name] == "qnx"
+          Train::File::Remote::Qnx.new(self, path, *args)
+        elsif os.windows?
+          Train::File::Remote::Windows.new(self, path, *args)
+        else
+          Train::File::Remote::Linux.new(self, path, *args)
+        end
       end
 
       def execute_on_channel(cmd, &data_handler)


### PR DESCRIPTION
### Description

This PR adds support for file_via_connection


Below is a short test script that monkey patches this plugin with the new method found in this PR.
```ruby
require "train-awsssm"

module TrainPlugins
  module AWSSSM
    class Connection < Train::Plugins::Transport::BaseConnection
      def file_via_connection(path)
        windows_instance? ? Train::File::Remote::Windows.new(self, path) : Train::File::Remote::Unix.new(self, path)
      end
    end
  end
end

train  = Train.create("awsssm", {
            host:     "i-00000000000000000",
            logger:   Logger.new($stdout, level: :info)
         })
conn   = train.connection

# RHEL:
# puts conn.file('/home/ssm-user/test-file.txt').content

# Windows:
# New-Item "C:\Users\Administrator\test-file.txt" -ItemType File -Value "The first sentence in our file."
puts conn.file('C:\\Users\\Administrator\\test-file.txt').content

conn.close
```

### Issues Resolved

Previously the plugin was not capable of interacting with files through the file_via_connection method. The fix is to choose a platform based on the OS. 

[This link references the train-core remote file resources](https://github.com/inspec/train/tree/master/lib/train/file/remote)

### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

